### PR TITLE
Update scalacss 0.4.1=>0.5.0

### DIFF
--- a/benchmark/src/main/scala/japgolly/scalajs/benchmark/Versions.scala
+++ b/benchmark/src/main/scala/japgolly/scalajs/benchmark/Versions.scala
@@ -6,6 +6,6 @@ object Versions {
   val Monocle       = "1.2.2"
   val React         = "15.3.1"
   val Scala211      = "2.11.8"
-  val ScalaCss      = "0.4.1"
+  val ScalaCss      = "0.5.0"
   val ScalaJsReact  = "0.11.1"
 }


### PR DESCRIPTION
Getting linking errors when I try to use 0.5.0 in my main project and 0.4.1 in my benchmark project.