### PR TITLE
Use `QueueExecutionContext` for CE benchmark

### DIFF
--- a/demo/src/main/scala/demo/suites/shootouts/AsyncEffectShootout.scala
+++ b/demo/src/main/scala/demo/suites/shootouts/AsyncEffectShootout.scala
@@ -9,6 +9,8 @@ import japgolly.scalajs.react.vdom.html_<^._
 import monocle.macros.GenIso
 import scala.scalajs.js
 import scala.scalajs.js.|
+import cats.effect.unsafe.IORuntime
+import cats.effect.unsafe.IORuntimeConfig
 
 object AsyncEffectShootout {
 
@@ -29,7 +31,14 @@ object AsyncEffectShootout {
 
   object CatsEffect extends Lib(Libraries.CatsEffect.fullName) {
     import cats.effect._
-    import cats.effect.unsafe.implicits.global
+    import scala.scalajs.concurrent.QueueExecutionContext
+    implicit val ioRuntime = IORuntime(
+      QueueExecutionContext.promises(),
+      QueueExecutionContext.promises(),
+      IORuntime.defaultScheduler,
+      () => (),
+      IORuntimeConfig()
+    )
 
     @inline private def toIO[A](f: => js.Promise[A]): IO[A] =
       IO.fromPromise(IO(f))

--- a/demo/src/main/scala/demo/suites/shootouts/AsyncEffectShootout.scala
+++ b/demo/src/main/scala/demo/suites/shootouts/AsyncEffectShootout.scala
@@ -94,8 +94,7 @@ object AsyncEffectShootout {
     override def toString = s"${lib.name} @ $size"
   }
 
-  // Disabling CatsEffect because it's quite misleading, see #217
-  val param1 = GuiParam.enumOf[Lib]("Library", /*CatsEffect,*/ JsPromise, ScalaJsReact, Zio)(_.name)
+  val param1 = GuiParam.enumOf[Lib]("Library", CatsEffect, JsPromise, ScalaJsReact, Zio)(_.name)
   val param2 = GuiParam.int("Size", 500)
 
   val iso = GenIso.fields[Params]

--- a/demo/src/main/scala/demo/suites/shootouts/AsyncEffectShootout.scala
+++ b/demo/src/main/scala/demo/suites/shootouts/AsyncEffectShootout.scala
@@ -9,8 +9,6 @@ import japgolly.scalajs.react.vdom.html_<^._
 import monocle.macros.GenIso
 import scala.scalajs.js
 import scala.scalajs.js.|
-import cats.effect.unsafe.IORuntime
-import cats.effect.unsafe.IORuntimeConfig
 
 object AsyncEffectShootout {
 
@@ -31,6 +29,7 @@ object AsyncEffectShootout {
 
   object CatsEffect extends Lib(Libraries.CatsEffect.fullName) {
     import cats.effect._
+    import cats.effect.unsafe._
     import scala.scalajs.concurrent.QueueExecutionContext
     implicit val ioRuntime = IORuntime(
       QueueExecutionContext.promises(),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
     val utest        = "0.7.10"
 
     // Demo only
-    val catsEffect      = "3.2.9"
+    val catsEffect      = "3.3.0"
     val scalaJsJavaTime = "2.3.0"
     val scalaz          = "7.3.5"
     val shapeless       = "2.3.7"


### PR DESCRIPTION
This "closes" https://github.com/japgolly/scalajs-benchmark/issues/217.

The problem with the benchmarks was that they were not directly measuring `IO`, but instead measuring the [`MacrotaskExecutor`](https://github.com/scala-js/scala-js-macrotask-executor) vs the default executor in Scala.js (the `QueueExecutionContext`) that all the other effects are using. Since the `MacrotaskExecutor` is much slower than `QueueExecutionContext` it results in Cats Effect performing poorly in the benchmark.

A "fair" comparison of effects should use the same EC, so here I switched the `IORuntime` to also use the `QueueExecutionContext`. There are good reasons not to do this in practice, but it seems reasonable for the purposes of this benchmark. Also this was easier than figuring out how to use the `MacrotaskExecutor` for all the other effect types (not even sure if this is possible).

Btw, a bit late but I did see your wonderful news the other day, I am relieved and overjoyed to hear you are doing much better and happier! 🤗  ❤️ 